### PR TITLE
Improve monitoring graphs, overlay sync, and startup

### DIFF
--- a/.agents/skills/astra-orchestrator/SKILL.md
+++ b/.agents/skills/astra-orchestrator/SKILL.md
@@ -1,0 +1,426 @@
+---
+name: astra-orchestrator
+description: Orchestrate complex Codex coding work with the root agent as planner/integrator, Luna subagents for exploration, implementation, testing, and research, and an Astra reviewer. Use for multi-file features, debugging across components, repo-wide changes, parallelizable workstreams, or whenever the user asks to delegate or use subagents. Do not use for trivial one-file edits or simple questions.
+---
+
+# Astra Orchestrator
+
+The user's explicit instructions take precedence over this skill.
+
+## Goal
+
+Use the root agent as the high-quality orchestrator.
+
+Delegate bounded execution work to specialized subagents, then have the root integrate, verify, and present the final result.
+
+The expected default topology is:
+
+- root: GPT-6 Astra (Pro plan) or GPT-5.6 Luna at max reasoning (Plus plan)
+- explorer: GPT-5.6 Luna
+- worker: GPT-5.6 Luna
+- tester: GPT-5.6 Luna
+- reviewer: GPT-6 Astra
+- researcher: GPT-5.6 Luna
+
+Use Luna for all routine subagent execution.
+
+This is a requirement, not a preference.
+
+Only the reviewer uses Astra by default.
+
+Do not override a Luna subagent to a more expensive model unless the user explicitly asks for escalation or a Luna worker reports that the task requires higher-level reasoning.
+
+---
+
+## Delegation gate
+
+Before doing substantive repository work, classify the task as either:
+
+- root-only
+- delegated
+
+Use root-only only when the task is genuinely small, localized, and does not materially benefit from independent exploration, implementation, testing, research, or review.
+
+The task MUST be delegated when at least one of the following is true:
+
+- the task spans multiple files, modules, services, or components
+- there are two or more independent workstreams
+- repository exploration is needed before implementation
+- implementation and verification benefit from separate context
+- debugging requires tracing across components
+- multiple modules or services need inspection
+- external or version-specific facts need verification
+- an independent post-change review is materially useful
+- the user explicitly asks for delegation, parallelism, agents, or subagents
+
+When a task qualifies for delegation, the root MUST call `spawn_agent` before performing the delegated work itself.
+
+Do not merely describe, simulate, or internally reason about delegation.
+
+Actual subagents must be spawned.
+
+If `spawn_agent` is unavailable or fails, explicitly report that failure.
+
+Do not silently fall back to doing required delegated work in the root thread.
+
+For every delegated task, spawn at least one subagent.
+
+Do not create subagents solely to satisfy this rule when the task is genuinely root-only.
+
+---
+
+## Root-agent responsibilities
+
+The root agent owns:
+
+1. understanding the user's actual goal
+2. choosing the architecture and implementation direction
+3. decomposing the task
+4. deciding which tasks can run in parallel
+5. spawning the appropriate subagents
+6. giving each subagent a bounded contract
+7. resolving conflicting subagent findings
+8. integrating changes
+9. reviewing the final diff
+10. running or coordinating final verification
+11. presenting the final result to the user
+
+Subagents provide evidence and bounded execution.
+
+They do not own the overall direction.
+
+The root must not offload architectural ownership to a subagent.
+
+---
+
+## Spawn policy
+
+When spawning agents, use these models by default:
+
+- explorer: `gpt-5.6-luna`
+- worker: `gpt-5.6-luna`
+- tester: `gpt-5.6-luna`
+- researcher: `gpt-5.6-luna`
+- reviewer: `gpt-6-astra`
+
+The root keeps the model configured in `config.toml`: `gpt-6-astra` on the Pro plan, `gpt-5.6-luna` at max reasoning on the Plus plan. Do not change the root model from within a session.
+
+For every delegated task:
+
+1. call `spawn_agent`
+2. give the agent a descriptive task name using underscores
+3. explicitly specify the intended model
+4. give the subagent a bounded delegation contract
+5. retain the returned task name or identifier
+6. wait for required agents before final synthesis
+
+Do not silently substitute the root agent for a required Luna worker.
+
+Do not spawn Astra workers except for the `reviewer` role unless:
+
+- the user explicitly requests Astra
+- Luna reports a genuinely difficult reasoning blocker
+- the root determines that a high-risk architectural or security review needs Astra
+
+Routine execution should remain on Luna.
+
+---
+
+## Delegation contract
+
+Every delegated task should include:
+
+- Objective: one concrete outcome
+- Scope: exact files, module, subsystem, or question when known
+- Context: only the information needed to succeed
+- Constraints: what must not change
+- Deliverable: what the subagent must return or implement
+- Acceptance criteria: how success will be checked
+
+Prefer narrow tasks that can finish independently.
+
+Bad:
+
+> Fix the backend.
+
+Good:
+
+> Trace where POST /invoices validates currency. Return the responsible files, validation path, and existing tests. Do not edit files.
+
+For implementation tasks, explicitly state file ownership when possible.
+
+For exploration tasks, tell the agent not to edit files.
+
+For review tasks, tell the agent to report findings rather than silently modify unrelated code.
+
+---
+
+## Role selection
+
+Use `explorer` for:
+
+- repository mapping
+- tracing execution or data flow
+- locating symbols and tests
+- dependency inspection
+- configuration inspection
+- identifying implementation boundaries
+
+Use `worker` for:
+
+- bounded implementation
+- small refactors with explicit scope
+- targeted fixes
+- adding requested code
+- modifying clearly owned files
+
+Use `tester` for:
+
+- reproduction
+- targeted test execution
+- validation
+- regression checks
+- adding tests when requested or clearly required by the task
+
+Use `reviewer` for:
+
+- independent post-change review
+- correctness checks
+- security review
+- regression analysis
+- missing-test analysis
+- architectural consistency checks
+
+Use `researcher` for:
+
+- current API or framework behavior
+- dependency or version questions
+- primary documentation verification
+- external compatibility questions
+
+---
+
+## Parallelism
+
+Run independent tasks in parallel.
+
+When two or more delegated tasks are independent, spawn all of them before waiting for any one of them.
+
+Good parallel set:
+
+1. spawn backend explorer
+2. spawn frontend explorer
+3. spawn API researcher
+4. wait for all three
+5. synthesize findings
+
+Do not do this:
+
+1. spawn backend explorer
+2. wait
+3. spawn frontend explorer
+4. wait
+5. spawn researcher
+6. wait
+
+unless later tasks genuinely depend on earlier results.
+
+Good parallel examples:
+
+- explorer maps backend path
+- explorer maps frontend path
+- researcher verifies external API behavior
+
+Serialize dependent work:
+
+1. explore
+2. decide architecture
+3. implement
+4. test
+5. review
+6. fix material findings
+7. final verification
+
+Do not send multiple workers to edit the same files unless the root explicitly coordinates ownership.
+
+Prefer one writer per file or subsystem.
+
+---
+
+## Default coding workflow
+
+For non-trivial implementation tasks, prefer this sequence:
+
+1. spawn one or more Luna explorers if repository understanding is needed
+2. wait for exploration results
+3. root decides implementation direction
+4. spawn Luna worker or workers with bounded ownership
+5. wait for implementation
+6. spawn Luna tester
+7. wait for validation
+8. spawn Astra reviewer when an independent review is materially useful
+9. resolve material findings
+10. run final verification
+11. present the result
+
+Do not spawn every role mechanically.
+
+Use only the roles that materially improve the task.
+
+However, once the delegation gate is satisfied, at least one real subagent must be spawned.
+
+---
+
+## Debugging workflow
+
+For cross-component bugs:
+
+1. spawn explorers for independent suspected areas
+2. reproduce the issue when possible
+3. collect evidence before selecting a fix
+4. root determines the likely root cause
+5. assign a bounded Luna worker to implement the fix
+6. assign Luna tester to reproduce the original failure and validate the fix
+7. use Astra reviewer for high-risk or non-obvious fixes
+
+Do not let multiple workers independently attempt competing fixes unless the root intentionally requests alternative approaches.
+
+---
+
+## Research workflow
+
+When current or version-specific external information matters:
+
+1. spawn a Luna researcher
+2. require primary or authoritative sources when possible
+3. return concise findings and compatibility implications
+4. let the root decide how those findings affect implementation
+
+Do not mix speculative external claims into implementation decisions without verification.
+
+---
+
+## Cost and context discipline
+
+Use Luna for routine subagent execution.
+
+Keep the root context focused on:
+
+- architectural decisions
+- summarized evidence
+- important diffs
+- test results
+- reviewer findings
+- unresolved risks
+
+Do not paste large raw logs or entire files back into the root when a concise evidence summary is enough.
+
+Subagents should return:
+
+- conclusions
+- relevant file paths
+- important line or symbol references
+- commands run
+- test results
+- risks or blockers
+
+Avoid returning large amounts of irrelevant raw output.
+
+---
+
+## Escalation behavior
+
+A subagent should report back instead of expanding scope when it encounters:
+
+- an architectural decision
+- a breaking API or schema change
+- a new dependency
+- a security-sensitive design choice
+- unclear requirements with materially different outcomes
+- unexpected changes outside its assigned scope
+- changes that affect another worker's ownership
+- a blocker that requires substantially broader reasoning
+
+The root decides what to do next.
+
+Luna should not independently escalate itself to a more expensive model.
+
+The root owns model escalation decisions.
+
+---
+
+## Failure handling
+
+If a subagent fails:
+
+1. inspect the failure reason
+2. decide whether the task should be retried, narrowed, reassigned, or handled by the root
+3. do not silently ignore the failed delegation
+4. do not claim the delegated work completed successfully
+
+If `spawn_agent` itself fails, explicitly note the failure.
+
+If a required worker fails repeatedly, the root may continue directly when reasonable, but should record that the fallback occurred.
+
+---
+
+## Delegated-task completion gate
+
+Before producing the final answer for a delegated task, confirm that:
+
+- every required subagent was actually spawned
+- every required subagent either completed or explicitly failed
+- material findings were integrated
+- conflicting findings were resolved
+- required verification was performed
+- no required agent is still running
+
+Do not finish while required subagents are still running.
+
+Do not claim delegation occurred unless `spawn_agent` was actually called successfully.
+
+---
+
+## Final verification
+
+Before claiming completion, the root should:
+
+1. inspect the final diff
+2. confirm the requested behavior is actually implemented
+3. check material reviewer findings
+4. run or confirm the highest-value tests
+5. verify that delegated results were integrated correctly
+6. state any validation that could not be performed
+
+For implementation tasks, prefer checking:
+
+- syntax or type checks
+- targeted unit tests
+- integration tests where relevant
+- build success where relevant
+- the original reproduction path
+- final diff for unintended changes
+
+---
+
+## User-facing behavior
+
+Do not narrate every subagent action unless the user asks for detailed orchestration visibility.
+
+The final answer should focus on:
+
+- what changed
+- what was verified
+- important findings
+- remaining risks or limitations
+
+When useful, briefly mention which agents contributed.
+
+If the user explicitly asks to see delegation, report:
+
+- subagent name
+- model
+- assigned task
+- completion status
+
+Do not claim a Luna agent was used unless the trace contains a successful `spawn_agent` call using `gpt-5.6-luna`.

--- a/.codex/agents/explorer.toml
+++ b/.codex/agents/explorer.toml
@@ -1,0 +1,30 @@
+name = "explorer"
+description = "Read-only repository explorer. Use to locate files, symbols, execution paths, dependencies, configuration, and tests before implementation."
+
+model = "gpt-5.6-luna"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+You are the repository exploration subagent.
+
+Your job is to gather evidence for the parent orchestrator, not to implement changes.
+
+Do:
+- locate the smallest set of relevant files and symbols
+- trace the real call or data flow
+- identify existing patterns, tests, configuration, and constraints
+- cite exact file paths and important symbols
+- call out uncertainty and conflicting evidence
+
+Do not:
+- edit files
+- propose large redesigns unless the parent explicitly asks
+- wander into unrelated parts of the repository
+
+Return a concise report:
+1. Relevant files/symbols
+2. Execution/data flow
+3. Constraints and risks
+4. Recommended implementation surface
+"""

--- a/.codex/agents/researcher.toml
+++ b/.codex/agents/researcher.toml
@@ -1,0 +1,22 @@
+name = "researcher"
+description = "Read-only technical research subagent. Use for version-specific APIs, framework behavior, external documentation, or dependency facts that should be verified."
+
+model = "gpt-5.6-luna"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+You are a technical research subagent.
+
+Verify facts using the best documentation or tools available in the session.
+Prefer primary documentation and repository source over blogs or memory.
+
+Focus only on the question delegated by the parent.
+Do not edit application code.
+
+Return:
+1. Verified answer
+2. Version/date assumptions
+3. Exact references or links when available
+4. Any uncertainty that could affect implementation
+"""

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,0 +1,32 @@
+name = "reviewer"
+description = "Read-only code reviewer. Use after implementation to find correctness, security, regression, concurrency, data-integrity, and missing-test risks."
+
+model = "gpt-6-astra"
+model_reasoning_effort = "low"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+You are an independent code review subagent.
+
+Review the actual change, not the intended story.
+
+Prioritize:
+- correctness bugs
+- behavior regressions
+- security and permission issues
+- data loss or integrity risks
+- race/concurrency problems
+- API or compatibility breaks
+- missing high-value tests
+
+Avoid style-only comments unless they hide a real defect.
+
+For each finding include:
+- severity
+- exact file/symbol
+- why it is a problem
+- a concrete fix or validation step
+
+If there are no material findings, say so clearly and name any residual uncertainty.
+Do not edit files.
+"""

--- a/.codex/agents/tester.toml
+++ b/.codex/agents/tester.toml
@@ -1,0 +1,28 @@
+name = "tester"
+description = "Verification subagent. Use to run targeted tests, reproduce failures, add missing tests when requested, and report exact evidence."
+
+model = "gpt-5.6-luna"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the test and verification subagent.
+
+Verify the delegated behavior independently.
+
+Prefer:
+- the smallest test command that proves or disproves the behavior
+- existing project test tooling
+- deterministic reproduction steps
+- exact failure output and file/test names
+
+Only modify files when the parent explicitly asks you to add or repair tests.
+Do not rewrite production code to make a test pass.
+
+Return:
+1. Commands run
+2. Pass/fail result
+3. Relevant output or reproduction
+4. Coverage gaps
+5. Suggested next action
+"""

--- a/.codex/agents/worker.toml
+++ b/.codex/agents/worker.toml
@@ -1,0 +1,29 @@
+name = "worker"
+description = "Implementation subagent for bounded coding tasks. Use after the relevant code path and acceptance criteria are understood."
+
+model = "gpt-5.6-luna"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are an implementation subagent.
+
+Implement only the bounded task delegated by the parent orchestrator.
+
+Rules:
+- stay inside the assigned scope
+- prefer the smallest defensible change
+- follow existing repository patterns
+- avoid unrelated refactors
+- do not change architecture, public APIs, schemas, or dependencies unless explicitly authorized
+- add or update targeted tests when appropriate
+- run focused validation for what you changed
+
+If the task becomes ambiguous or requires a wider architectural decision, stop expanding scope and report the decision needed to the parent.
+
+Return:
+1. What changed
+2. Files modified
+3. Validation/tests run
+4. Remaining risks or decisions
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,35 @@
+# Codex: Luna orchestrator + Luna subagents (Plus plan)
+#
+# Variant of config.toml for Codex Plus users. The root runs on GPT-5.6 Luna
+# at maximum reasoning instead of GPT-6 Astra, so the largest thread in an
+# orchestrated session stays on the cheaper model. The reviewer role in
+# agents/reviewer.toml is still pinned to Astra for an independent review.
+#
+# The installer writes this file as <repo>/.codex/config.toml when you
+# select the Plus plan. For a personal/global setup, merge these settings
+# into ~/.codex/config.toml instead.
+#
+# Main knobs to change:
+#   model / model_reasoning_effort
+#   agents.default_subagent_model
+#   agents.default_subagent_reasoning_effort
+#   agents.max_concurrent_threads_per_session
+
+# Root / orchestrator
+model = "gpt-5.6-luna"
+model_reasoning_effort = "max"
+
+# Safe interactive defaults. Change if your workflow needs otherwise.
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+[agents]
+enabled = true
+
+# Number of child agent threads Codex may keep open concurrently.
+# Keep this low on Plus: every concurrent subagent re-reads its own context.
+max_concurrent_threads_per_session = 4
+
+# Default for any spawned subagent that does not explicitly choose a model.
+default_subagent_model = "gpt-5.6-luna"
+default_subagent_reasoning_effort = "medium"

--- a/src/main/build-kind.js
+++ b/src/main/build-kind.js
@@ -2,9 +2,18 @@ import path from 'node:path';
 
 export const PORTABLE_EXECUTABLE_NAME = 'Arc-Power_Portable.exe';
 
+const PORTABLE_EXECUTABLE_LAUNCH_PATTERN = /^arc[- _]?power[- _]?portable(?:[- _.(].*)?\.exe$/i;
+
 function validatedPortablePath(value) {
   if (typeof value !== 'string' || !path.isAbsolute(value)) return null;
   return path.basename(value).toLowerCase() === PORTABLE_EXECUTABLE_NAME.toLowerCase()
+    ? path.resolve(value)
+    : null;
+}
+
+function actualPortableLaunchPath(value) {
+  if (typeof value !== 'string' || !path.isAbsolute(value)) return null;
+  return PORTABLE_EXECUTABLE_LAUNCH_PATTERN.test(path.basename(value))
     ? path.resolve(value)
     : null;
 }
@@ -17,6 +26,22 @@ export function resolvePortableWrapperPath({ portableExecutableFile = null, port
   return validatedPortablePath(portableExecutableFile)
     ?? validatedPortablePath(directoryCandidate)
     ?? validatedPortablePath(parentExecutableFile);
+}
+
+/**
+ * Resolve the executable that actually launched a packaged Portable build for
+ * startup registration. Unlike the build/update classifier above, this must
+ * retain Windows' duplicate-download suffixes such as " (1)"; pointing the
+ * startup task at a guessed canonical filename can launch an older copy or a
+ * path that no longer exists.
+ */
+export function resolvePortableStartupPath({ portableExecutableFile = null, portableExecutableDir = null, parentExecutableFile = null } = {}) {
+  const directoryCandidate = typeof portableExecutableDir === 'string' && path.isAbsolute(portableExecutableDir)
+    ? path.join(portableExecutableDir, PORTABLE_EXECUTABLE_NAME)
+    : null;
+  return actualPortableLaunchPath(portableExecutableFile)
+    ?? actualPortableLaunchPath(parentExecutableFile)
+    ?? actualPortableLaunchPath(directoryCandidate);
 }
 
 // Arc Power - the app:build-info distribution-kind derivation (electron-free,

--- a/src/main/installer-pure.js
+++ b/src/main/installer-pure.js
@@ -22,6 +22,11 @@ export const LEGACY_RUN_VALUE_NAMES = Object.freeze(['Arc Power']);
 export const CLEANUP_RUN_VALUE_NAMES = Object.freeze([CURRENT_RUN_VALUE_NAME, ...LEGACY_RUN_VALUE_NAMES]);
 export const UPDATE_PARENT_PID_ARG = '--update-parent-pid';
 export const UPDATE_INSTALL_DIR_ARG = '--update-install-dir';
+// The custom Installer clears the portable-wrapper markers before it launches
+// the installed executable. This handoff marker prevents the child from
+// mistaking its Installer parent for another installer launch when the parent
+// query runs before Explorer reparents the detached process.
+export const INSTALLED_LAUNCH_ENV = 'ARC_POWER_INSTALLED_LAUNCH';
 
 function requireAbsolute(value, label) {
   if (typeof value !== 'string' || value.length === 0 || !path.isAbsolute(value)) {

--- a/src/main/installer.js
+++ b/src/main/installer.js
@@ -21,6 +21,7 @@ import { applyWindowIconLifecycle, resolveWindowIconPath } from './window-icon.j
 import {
   PRODUCT_NAME,
   INSTALLED_EXECUTABLE_NAME,
+  INSTALLED_LAUNCH_ENV,
   createInstallationPlan,
   createUninstallLaunchScript,
   createUninstallCleanupScript,
@@ -290,6 +291,7 @@ function launchInstalledApp(executablePath, workingDirectory) {
   delete environment.PORTABLE_EXECUTABLE_FILE;
   delete environment.PORTABLE_EXECUTABLE_DIR;
   delete environment.PORTABLE_EXECUTABLE_APP_FILENAME;
+  environment[INSTALLED_LAUNCH_ENV] = '1';
   return new Promise((resolve, reject) => {
     const child = spawn(executablePath, [], {
       cwd: workingDirectory,

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -83,10 +83,10 @@ import { createRecordingStatusPillWindow } from './recording-status-pill.js';
 // overlay.js stays untouched - this panel has its own lifecycle + its own
 // interactivity (NO setIgnoreMouseEvents).
 import { createAdvancedOverlayWindow } from './advanced-overlay.js';
-import { createStartup, createMockStartup, resolveLogonExecPath } from './startup.js';
+import { createStartup, createMockStartup } from './startup.js';
 import { attachStartupUpdateStatus, createStartupSplash } from './splash.js';
 import { runInstallerMode } from './installer.js';
-import { INSTALLED_EXECUTABLE_NAME, installerModeFromEnvironment, resolveNewerInstalledExecutable } from './installer-pure.js';
+import { INSTALLED_EXECUTABLE_NAME, INSTALLED_LAUNCH_ENV, installerModeFromEnvironment, resolveNewerInstalledExecutable } from './installer-pure.js';
 import { checkForUpdates } from './auto-update.js';
 import { createStartupUpdateCoordinator, shouldBlockStartupSplashClose } from './startup-update.js';
 import { createStartupUpdateHandoff } from './startup-update-handoff.js';
@@ -107,7 +107,7 @@ import { applyProfile, runApplyOnStartup, applyProfileBoot, resolveApplyDeviceId
 import { runBootApplyMode } from './boot-apply-mode.js';
 import { shouldUseInstanceLock, acquireInstanceLock, focusExistingWindow } from './single-instance.js';
 import { createBootSetup, taskActionMatches } from './setup-boot.js';
-import { deriveBuildKind, resolvePortableWrapperPath } from './build-kind.js';
+import { deriveBuildKind, resolvePortableStartupPath, resolvePortableWrapperPath } from './build-kind.js';
 import { createTray, buildTrayMenuTemplate, trayToggleAction, TRAY_LABEL_TOGGLE, TRAY_LABEL_APPLY_PROFILE, trayBalloonForOutcome } from './tray.js';
 import { trayApplyActiveProfile } from './tray-apply.js';
 import { isElevated as isElevatedReal } from './elevation.js';
@@ -274,7 +274,15 @@ function redirectStaleInstalledLaunch() {
   }
 }
 
-const parentExecutableFile = process.env.PORTABLE_EXECUTABLE_FILE ? null : portableParentExecutableFile();
+const installedLaunchHandoff = process.env[INSTALLED_LAUNCH_ENV] === '1';
+const parentExecutableFile = (process.env.PORTABLE_EXECUTABLE_FILE || installedLaunchHandoff)
+  ? null
+  : portableParentExecutableFile();
+const portableStartupPath = resolvePortableStartupPath({
+  portableExecutableFile: process.env.PORTABLE_EXECUTABLE_FILE ?? null,
+  portableExecutableDir: process.env.PORTABLE_EXECUTABLE_DIR ?? null,
+  parentExecutableFile,
+});
 const portableWrapperPath = resolvePortableWrapperPath({
   portableExecutableFile: process.env.PORTABLE_EXECUTABLE_FILE ?? null,
   portableExecutableDir: process.env.PORTABLE_EXECUTABLE_DIR ?? null,
@@ -2245,7 +2253,11 @@ async function main() {
   const startup = mock
     ? createMockStartup()
     : createStartup({
-        logonExecPath: await resolveLogonExecPath({ execPath: process.execPath, isPackaged: app.isPackaged }),
+        // The portable wrapper path is already proven by its stable filename
+        // and wrapper markers. Installed builds must always register their
+        // own executable; querying an Installer parent here could otherwise
+        // leave a startup task pointing back at a deleted setup EXE.
+        logonExecPath: portableStartupPath ?? process.execPath,
         useElevatedTask: app.isPackaged && process.platform === 'win32',
       });
   // Driver-date adapter: real reg.exe query in the product path; mock mode

--- a/src/main/recording-hotkeys.js
+++ b/src/main/recording-hotkeys.js
@@ -23,6 +23,9 @@ export function createRecordingHotkeys({ shortcut, getSettings, onAction, reserv
     // legacy value readable, but never register or invoke it.
     const actions = [['start', 'start'], ['stop', 'stop'], ['saveClip', 'saveClip'], ['screenshot', 'screenshot']];
     for (const [key, action] of actions) {
+      // An explicit empty shortcut is a durable opt-out, not a malformed
+      // value that should fall back to the default accelerator.
+      if (typeof settings.hotkeys?.[key] === 'string' && settings.hotkeys[key].trim() === '') continue;
       const accelerator = normalizeRecordingAccelerator(settings.hotkeys?.[key], key === 'start' ? 'F9' : key === 'stop' ? 'F10' : key === 'saveClip' ? 'F8' : 'F7');
       if (reservedAccelerators.has(accelerator) || Object.values(next.registered).includes(accelerator)) {
         next.conflicts[key] = accelerator;

--- a/src/main/recording-pure.js
+++ b/src/main/recording-pure.js
@@ -303,6 +303,10 @@ export function normalizeRecordingAccelerator(value, fallback) {
 }
 
 function normalizeHotkey(value, fallback) {
+  // An explicitly blank shortcut is an intentional opt-out. Missing fields
+  // still use the established defaults, while whitespace-only input is also
+  // treated as disabled after the user clears a control.
+  if (typeof value === 'string' && value.trim() === '') return '';
   return normalizeRecordingAccelerator(boundedString(value, fallback, 32), fallback);
 }
 

--- a/src/main/startup.js
+++ b/src/main/startup.js
@@ -145,7 +145,13 @@ export async function resolveLogonExecPath(deps = {}) {
     );
     const parent = String(stdout ?? '').trim();
     if (!parent) return execPath;
-    if (/arc[-\s_]?power/i.test(parent.split(/[\\/]/).pop() ?? '') && parent !== execPath) {
+    const parentName = parent.split(/[\\/]/).pop() ?? '';
+    // Only a portable wrapper is a stable logon target. The custom Installer
+    // can be the temporary parent of the installed app on its first launch;
+    // never persist that setup EXE as the installed app's startup target.
+    if (/arc[-\s_]?power/i.test(parentName)
+      && !/installer/i.test(parentName)
+      && parent !== execPath) {
       return parent;
     }
   } catch {

--- a/src/main/ui-verify.js
+++ b/src/main/ui-verify.js
@@ -4142,7 +4142,10 @@ export async function runUiVerify(win, backend, store, getTrayRebuilds = () => 0
       if (!axisValues.every(Number.isFinite) || axisValues[1] !== 0 || axisValues[0] <= 0) return { ok: false, why: 'invalid-zero-based-axis', axis: yTexts };
       const tooltipText = tooltip.textContent?.trim() ?? '';
       const sampleValue = Number(tooltipText);
-      const expectedY = height - 13 - ((sampleValue - axisValues[1]) / Math.max(.001, axisValues[0] - axisValues[1])) * Math.max(4, height - 18);
+      const graphStyle = getComputedStyle(surface);
+      const plotTop = Number.parseFloat(graphStyle.getPropertyValue('--telemetry-graph-plot-top')) || 5;
+      const plotBottom = Number.parseFloat(graphStyle.getPropertyValue('--telemetry-graph-plot-bottom')) || 13;
+      const expectedY = height - plotBottom - ((sampleValue - axisValues[1]) / Math.max(.001, axisValues[0] - axisValues[1])) * Math.max(4, height - plotTop - plotBottom);
       const mappedLine = Number.isFinite(sampleValue) && Number.isFinite(expectedY) && lineNear(crosshairX, expectedY);
       const popupRect = tooltip.getBoundingClientRect();
       const inside = popupRect.left >= surfaceRect.left - 1
@@ -4234,7 +4237,10 @@ export async function runUiVerify(win, backend, store, getTrayRebuilds = () => 0
     if (!axis.every(Number.isFinite) || axis[1] !== 0 || axis[0] <= 0) return { ok: false, why: 'invalid-zero-based-axis-after-tick', axis };
     const tooltipText = tooltip.textContent?.trim() ?? '';
     const sampleValue = Number(tooltipText);
-    const expectedY = height - 13 - ((sampleValue - axis[1]) / Math.max(.001, axis[0] - axis[1])) * Math.max(4, height - 18);
+    const graphStyle = getComputedStyle(surface);
+    const plotTop = Number.parseFloat(graphStyle.getPropertyValue('--telemetry-graph-plot-top')) || 5;
+    const plotBottom = Number.parseFloat(graphStyle.getPropertyValue('--telemetry-graph-plot-bottom')) || 13;
+    const expectedY = height - plotBottom - ((sampleValue - axis[1]) / Math.max(.001, axis[0] - axis[1])) * Math.max(4, height - plotTop - plotBottom);
     const dpr = window.devicePixelRatio || 1;
     const ctx = canvas.getContext('2d');
     const crosshairX = Number.parseFloat(crosshair.style.left);

--- a/src/renderer/advanced-overlay.ts
+++ b/src/renderer/advanced-overlay.ts
@@ -156,6 +156,7 @@ let recordingQuickDraft: RecordingSettings | null = null;
 let recordingQuickStatus: RecordingEngineState = EMPTY_RECORDING_STATUS;
 let recordingQuickTargets: RecordingCaptureTargets = { displays: [], windows: [] };
 let recordingQuickPillEnabled = false;
+let recordingQuickInitialized = false;
 let recordingQuickLoading = false;
 let recordingQuickActionBusy = false;
 let recordingQuickApplying = false;
@@ -178,6 +179,17 @@ function cloneRecordingQuickSettings(value: RecordingSettings): RecordingSetting
     hotkeys: { ...value.hotkeys },
     captureTarget: { ...value.captureTarget },
   };
+}
+
+function syncRecordingSettings(next: RecordingSettings): void {
+  // Keep the normalized push as the clean base even when Recording is not the
+  // visible tab. This prevents the one-time quick-settings load from bringing
+  // back values that were changed in the main Recording page meanwhile.
+  recordingQuickSettings = cloneRecordingQuickSettings(next);
+  if (!recordingQuickDirty && !recordingQuickApplying) {
+    recordingQuickDraft = cloneRecordingQuickSettings(next);
+  }
+  if (activeTab === 'recording') renderRecording();
 }
 
 function recordingQuickPatch(patch: RecordingSettingsPatch): void {
@@ -316,7 +328,7 @@ api.onStateUpdated((payload) => {
 // until the Recording tab is rebuilt.
 api.onRecordingSettingsUpdated((next) => {
   if (!next || typeof next !== 'object') return;
-  recordingSettingsSync?.(next);
+  syncRecordingSettings(next);
 });
 
 api.onRecordingPillSettingsUpdated((next) => {
@@ -410,7 +422,7 @@ api.onDeviceSelectionUpdated((payload) => {
 api.onGraphicsStateUpdated((payload) => {
   if (payload && payload.deviceId === store.get().deviceId && graphicsStateGeneration === panelGeneration) {
     graphicsState = payload.graphicsState;
-    if (activeTab === 'graphics' && !graphicsApplying) graphicsStateSync?.(payload.graphicsState);
+    if (activeTab === 'graphics') graphicsStateSync?.(payload.graphicsState);
   }
 });
 
@@ -943,15 +955,25 @@ async function renderTuning(): Promise<void> {
   };
 
   // Main-window, tray, and profile applies all arrive through the shared
-  // device-state push. Keep the panel's active Tuning controls in place and
-  // preserve any control that is already dirty or has an applied reference.
+  // device-state push. Keep the panel's active Tuning controls in place while
+  // preserving only a genuinely unsaved local draft. A clean control with an
+  // old Applied reference must still adopt an external read-back.
   tuningStateSync = (nextState: DeviceState): void => {
+    const previousState = currentState;
     currentState = nextState;
     for (const key of controls) {
-      if (key in applied) continue;
       const range = cardSliderRange(caps, key);
+      if (!range) continue;
+      const previous = previousState[key as keyof DeviceState];
+      const hasLocalDraft = key in applied
+        ? values[key] !== applied[key]
+        : typeof previous === 'number' && values[key] !== snapToRange(previous, range);
+      if (hasLocalDraft) continue;
       const raw = nextState[key as keyof DeviceState];
-      if (range && typeof raw === 'number' && Number.isFinite(raw)) values[key] = snapToRange(raw, range);
+      if (typeof raw === 'number' && Number.isFinite(raw)) {
+        values[key] = snapToRange(raw, range);
+        if (key in applied) applied[key] = values[key];
+      }
     }
     renderTuningInPlace();
   };
@@ -1140,7 +1162,7 @@ function normalizeRecordingQuickStatus(value: RecordingEngineState | null | unde
 }
 
 async function loadRecordingQuick(): Promise<void> {
-  if (recordingQuickLoading || recordingQuickSettings) return;
+  if (recordingQuickLoading || recordingQuickInitialized) return;
   recordingQuickLoading = true;
   recordingQuickError = null;
   renderRecording();
@@ -1149,16 +1171,21 @@ async function loadRecordingQuick(): Promise<void> {
       api.recordingSettingsGet(),
       api.recordingStatus(),
     ]);
-    recordingQuickSettings = loadedSettings;
-    recordingQuickDraft = cloneRecordingQuickSettings(loadedSettings);
+    // A settings push can arrive before the first visit to this tab. Keep
+    // that normalized value as the authoritative quick-settings base while
+    // still loading the status, targets, and profile-backed pill state.
+    if (!recordingQuickSettings) {
+      recordingQuickSettings = loadedSettings;
+      recordingQuickDraft = cloneRecordingQuickSettings(loadedSettings);
+    }
     recordingQuickStatus = normalizeRecordingQuickStatus(loadedStatus);
-    recordingQuickDirty = false;
     const [targets, profileEnvelope] = await Promise.all([
       api.recordingCaptureTargets().catch(() => ({ displays: [], windows: [] })),
       api.profilesList().catch(() => null),
     ]);
     recordingQuickTargets = targets;
     recordingQuickPillEnabled = profileEnvelope?.settings?.overlayRecordingPill === true;
+    recordingQuickInitialized = true;
   } catch (err) {
     recordingQuickError = err instanceof Error ? err.message : String(err);
   } finally {
@@ -1449,21 +1476,15 @@ function renderStreamMode(): HTMLElement {
 }
 
 function renderRecording(): void {
-  recordingSettingsSync = (next: RecordingSettings): void => {
-    recordingQuickSettings = next;
-    // Keep a local unsaved quick-control draft intact while adopting the
-    // pushed settings as the clean base. Clean controls update immediately.
-    if (!recordingQuickDirty && !recordingQuickApplying) recordingQuickDraft = cloneRecordingQuickSettings(next);
-    if (activeTab === 'recording') renderRecording();
-  };
+  recordingSettingsSync = syncRecordingSettings;
   closeOpenAdvancedMenu();
   clear(contentEl);
   const view = el('div', { class: 'adv-view recording-view' });
   view.append(el('div', { class: 'adv-view-heading' }, [el('p', { class: 'adv-view-title', text: 'Recording' })]));
-  if (recordingQuickLoading || !recordingQuickSettings) {
+  if (recordingQuickLoading || !recordingQuickInitialized) {
     view.append(el('p', { class: 'page-subtitle', text: recordingQuickError ?? 'Loading recording settings…' }));
     contentEl.append(view);
-    if (!recordingQuickLoading && !recordingQuickSettings) void loadRecordingQuick();
+    if (!recordingQuickLoading && !recordingQuickInitialized) void loadRecordingQuick();
     return;
   }
   view.append(renderRecordingQuickActions(), renderRecordingQuickSettings(), renderStreamMode());
@@ -1803,14 +1824,23 @@ function renderGraphicsCards(view: HTMLElement): void {
 
   // Keep the visible dropdowns and limiter slider synchronized with a
   // graphics apply made by the main window or another renderer. Dirty local
-  // controls retain their draft; untouched controls adopt the readback.
+  // controls retain their draft; clean controls (including previously
+  // applied controls) adopt the readback.
   graphicsStateSync = (nextState: GraphicsState): void => {
+    const previousState = state;
+    const preserveDraft = new Map<string, boolean>();
+    for (const key of GRAPHICS_CONTROLS) {
+      preserveDraft.set(key, isGraphicsControlDirtyVsApplied(key, graphicsDraft, previousState, graphicsApplied));
+    }
     state = nextState;
     graphicsState = nextState;
     const pushedDraft = normalizeGraphicsSettings(nextState);
     for (const key of GRAPHICS_CONTROLS) {
-      if (key in graphicsApplied) continue;
+      if (preserveDraft.get(key)) continue;
       if (key in pushedDraft) (graphicsDraft as Record<string, unknown>)[key] = (pushedDraft as Record<string, unknown>)[key];
+      if (key in graphicsApplied && key in pushedDraft) {
+        (graphicsApplied as Record<string, unknown>)[key] = (pushedDraft as Record<string, unknown>)[key];
+      }
     }
     for (const key of ['frameGenOverride', 'flipMode', 'lowLatency']) {
       const value = (graphicsDraft as Record<string, unknown>)[key];

--- a/src/renderer/pages/monitoring.ts
+++ b/src/renderer/pages/monitoring.ts
@@ -41,6 +41,8 @@ import {
   formatMonitoringGraphValue,
   graphDrawnPoints,
   graphSamplePosition,
+  MONITORING_GRAPH_PLOT_BOTTOM_PX,
+  monitoringGraphPlotHeight,
   monitoringGraphRangeForMax,
   monitoringGraphSegment,
 } from '../pure/monitoring-graph.ts';
@@ -610,7 +612,8 @@ function drawMiniSeries(canvas: HTMLCanvasElement, points: SeriesPoint[], series
   // Reserve the lower strip for the hover time label. Keep this coordinate
   // system in lockstep with updateMetricGraphOverlay so the crosshair and
   // pill remain attached to the rendered line after a resize.
-  const y = (value: number): number => h - 13 - ((value - min) / span) * Math.max(4, h - 18);
+  const y = (value: number): number => h - MONITORING_GRAPH_PLOT_BOTTOM_PX
+    - ((value - min) / span) * monitoringGraphPlotHeight(h);
   ctx.beginPath();
   drawn.forEach((point, index) => {
     const px = x(point);

--- a/src/renderer/pages/recording.ts
+++ b/src/renderer/pages/recording.ts
@@ -834,7 +834,10 @@ function renderHotkeys(): HTMLElement {
     return el('div', { class: 'recording-hotkey-row' }, [
       el('div', { class: 'recording-hotkey-copy' }, [el('strong', { text: label }), el('span', { text: description })]),
       input,
-      conflict ? el('span', { class: 'text-warn recording-hotkey-warning', text: `Not registered (${conflict} is in use)` }) : el('span', { class: 'recording-hotkey-registered', text: status.hotkeys.registered[key] ? 'Registered' : 'Not registered' }),
+      el('div', { class: 'recording-hotkey-status' }, [
+        conflict ? el('span', { class: 'text-warn recording-hotkey-warning', text: `Not registered (${conflict} is in use)` }) : null,
+        button('NONE', () => stagePatch({ hotkeys: { [key]: '' } as Partial<RecordingSettings['hotkeys']> }), 'btn btn-secondary recording-hotkey-none'),
+      ]),
     ]);
   };
   return el('section', { class: 'recording-panel' }, [

--- a/src/renderer/pure/monitoring-graph.ts
+++ b/src/renderer/pure/monitoring-graph.ts
@@ -8,6 +8,15 @@ import type { SeriesPoint } from './graph.ts';
 /** Maximum number of points painted into a compact Monitoring sparkline. */
 export const MONITORING_GRAPH_MAX_POINTS = 72;
 
+/** Vertical padding reserved outside the drawable Monitoring plot band. */
+export const MONITORING_GRAPH_PLOT_TOP_PX = 5;
+export const MONITORING_GRAPH_PLOT_BOTTOM_PX = 13;
+
+/** Return the drawable height used by both the Canvas line and hover overlay. */
+export function monitoringGraphPlotHeight(height: number): number {
+  return Math.max(4, height - MONITORING_GRAPH_PLOT_TOP_PX - MONITORING_GRAPH_PLOT_BOTTOM_PX);
+}
+
 export interface GraphRange {
   min: number;
   max: number;
@@ -107,8 +116,8 @@ export function graphAxisTime(points: SeriesPoint[], index: number): string {
 }
 
 /**
- * Position a nearest sample using the same 2 px endpoint margins and lower
- * 13 px X-label strip as the Canvas renderer.
+ * Position a nearest sample using the same 2 px endpoint margins and plot
+ * band as the Canvas renderer.
  */
 export function graphSamplePosition(
   points: SeriesPoint[],
@@ -116,8 +125,8 @@ export function graphSamplePosition(
   width: number,
   height: number,
   range: GraphRange,
-  bottomPadding = 13,
-  plotHeight = Math.max(4, height - 18),
+  bottomPadding = MONITORING_GRAPH_PLOT_BOTTOM_PX,
+  plotHeight = monitoringGraphPlotHeight(height),
 ): GraphSamplePosition | null {
   if (points.length === 0 || index < 0 || index >= points.length || width <= 0 || height <= 0) return null;
   const timeSpan = Math.max(0.001, points[points.length - 1].t - points[0].t);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2406,18 +2406,18 @@ input[type="number"] {
 .telemetry-panel-body[hidden] { display: none; }
 .telemetry-metric-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr)); gap: 6px; }
 .telemetry-panel[data-telemetry-panel="fps"] .telemetry-metric-grid { grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr)); }
-.telemetry-metric { min-width: 0; min-height: 56px; display: grid; grid-template-columns: minmax(0, .92fr) minmax(0, 1.08fr); align-items: center; gap: 7px; padding: 6px 7px; border: 1px solid color-mix(in srgb, var(--border) 86%, var(--accent)); border-radius: 6px; background: color-mix(in srgb, var(--bg-inset) 82%, var(--bg-elev)); }
+.telemetry-metric { min-width: 0; min-height: 96px; display: grid; grid-template-columns: minmax(0, .92fr) minmax(0, 1.08fr); align-items: center; gap: 7px; padding: 6px 7px; border: 1px solid color-mix(in srgb, var(--border) 86%, var(--accent)); border-radius: 6px; background: color-mix(in srgb, var(--bg-inset) 82%, var(--bg-elev)); }
 .telemetry-metric-copy { min-width: 0; display: grid; grid-template-rows: auto auto; align-items: end; }
-.telemetry-metric-graph { min-width: 0; display: grid; align-content: center; gap: 2px; overflow: visible; }
+.telemetry-metric-graph { --telemetry-graph-height: 80px; --telemetry-graph-plot-top: 5px; --telemetry-graph-plot-bottom: 13px; min-width: 0; display: grid; align-content: center; gap: 2px; overflow: visible; }
 .telemetry-metric-graph-layout { width: calc(100% + 30px); min-width: 0; margin-left: -30px; display: grid; grid-template-columns: 24px minmax(0, 1fr); gap: 6px; align-items: stretch; }
-.telemetry-graph-axis-rail { position: relative; min-width: 0; height: 48px; overflow: hidden; }
-.telemetry-metric-graph-surface { position: relative; min-width: 0; height: 48px; overflow: hidden; }
+.telemetry-graph-axis-rail { position: relative; min-width: 0; height: var(--telemetry-graph-height); overflow: hidden; }
+.telemetry-metric-graph-surface { position: relative; min-width: 0; height: var(--telemetry-graph-height); overflow: hidden; }
 .telemetry-metric-value-line { min-width: 0; display: inline-flex; align-items: baseline; gap: 4px; max-width: 100%; }
 .telemetry-metric-value { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text); font: 650 20px var(--mono); line-height: 1.05; font-variant-numeric: tabular-nums; }
 .telemetry-metric-unit { flex: 0 0 auto; color: var(--accent); font: 550 10px var(--mono); white-space: nowrap; }
 .telemetry-metric-label { min-width: 0; margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-muted); font-size: 10px; }
-.telemetry-metric-sparkline { position: relative; z-index: 1; display: block; width: 100%; height: 48px; min-width: 0; border-radius: 3px; background-color: transparent; }
-.telemetry-graph-grid { position: absolute; top: 5px; right: 0; bottom: 13px; left: 0; z-index: 0; pointer-events: none; }
+.telemetry-metric-sparkline { position: relative; z-index: 1; display: block; width: 100%; height: var(--telemetry-graph-height); min-width: 0; border-radius: 3px; background-color: transparent; }
+.telemetry-graph-grid { position: absolute; top: var(--telemetry-graph-plot-top); right: 0; bottom: var(--telemetry-graph-plot-bottom); left: 0; z-index: 0; pointer-events: none; }
 .telemetry-graph-grid-line { position: absolute; display: block; background: color-mix(in srgb, var(--border) 42%, transparent); }
 .telemetry-graph-grid-h { right: 0; left: 0; height: 1px; }
 .telemetry-graph-grid-top { top: 0; }
@@ -2433,8 +2433,8 @@ input[type="number"] {
 .telemetry-graph-axis-label[hidden], .telemetry-graph-crosshair[hidden], .telemetry-graph-tooltip[hidden] { display: none; }
 .telemetry-graph-axis-y { left: 0; right: 0; }
 .telemetry-graph-axis-y-max { top: 2px; }
-.telemetry-graph-axis-y-min { bottom: 13px; }
-.telemetry-graph-crosshair { position: absolute; top: 5px; bottom: 13px; z-index: 2; width: 1px; transform: translateX(-.5px); border-left: 1px dashed color-mix(in srgb, #38c5ff 76%, transparent); box-shadow: 0 0 6px rgba(56, 197, 255, .35); pointer-events: none; }
+.telemetry-graph-axis-y-min { bottom: var(--telemetry-graph-plot-bottom); }
+.telemetry-graph-crosshair { position: absolute; top: var(--telemetry-graph-plot-top); bottom: var(--telemetry-graph-plot-bottom); z-index: 2; width: 1px; transform: translateX(-.5px); border-left: 1px dashed color-mix(in srgb, #38c5ff 76%, transparent); box-shadow: 0 0 6px rgba(56, 197, 255, .35); pointer-events: none; }
 .telemetry-graph-tooltip { position: absolute; z-index: 5; max-width: calc(100% - 4px); overflow: hidden; transform: none; padding: 0; border: 0; border-radius: 0; background: transparent; color: #38c5ff; box-shadow: none; font: 550 8px var(--mono); line-height: 1; text-overflow: ellipsis; text-shadow: 0 1px 2px rgba(4, 7, 14, .9); white-space: nowrap; pointer-events: none; }
 .telemetry-metric-sparkline-empty { opacity: .7; }
 .telemetry-section-heading { display: flex; align-items: flex-start; gap: 10px; margin-bottom: 9px; }
@@ -2498,7 +2498,7 @@ input[type="number"] {
   .telemetry-panel[data-telemetry-panel="fps"] .telemetry-metric-grid,
   .telemetry-metric-grid { grid-template-columns: 1fr; }
   .telemetry-metric { grid-template-columns: minmax(92px, .78fr) minmax(0, 1.22fr); }
-  .telemetry-metric-graph-surface, .telemetry-metric-sparkline, .telemetry-graph-axis-rail { height: 42px; }
+  .telemetry-metric-graph { --telemetry-graph-height: 68px; }
 }
 
 .seg-stack {
@@ -3335,11 +3335,13 @@ input[type="number"] {
 .recording-process-select { width: 100%; }
 .recording-process-select:disabled { opacity: .52; cursor: not-allowed; }
 .recording-process-refresh { align-self: flex-start; margin-top: 2px; }
-.recording-hotkey-row { display: grid; grid-template-columns: minmax(160px, 1fr) 150px 120px; gap: 12px; align-items: center; padding: 9px 0; border-top: 1px solid var(--border); font-size: 12px; }
+.recording-hotkey-row { display: grid; grid-template-columns: minmax(160px, 1fr) 150px minmax(70px, 1fr); gap: 12px; align-items: center; padding: 9px 0; border-top: 1px solid var(--border); font-size: 12px; }
 .recording-hotkey-row:first-of-type { border-top: 0; }
+.recording-hotkey-none { min-height: 34px; padding-inline: 8px; font: 700 10px var(--mono); letter-spacing: .04em; }
 .recording-hotkey { width: 150px; font-family: var(--mono); }
 .recording-hotkey-copy { display: flex; flex-direction: column; gap: 2px; }
-.recording-hotkey-copy span, .recording-hotkey-registered { color: var(--text-dim); font-size: 11px; }
+.recording-hotkey-copy span { color: var(--text-dim); font-size: 11px; }
+.recording-hotkey-status { display: flex; align-items: center; gap: 8px; min-width: 0; }
 .recording-hotkey-warning { font-size: 11px; }
 .recording-storage-panel { display: grid; grid-template-columns: minmax(170px, .6fr) minmax(260px, 1fr); gap: 12px 16px; }
 .recording-storage-panel .recording-panel-heading { grid-column: 1 / -1; }
@@ -3636,7 +3638,7 @@ input[type="number"] {
 @media (max-width: 900px) { .recording-editor-ascent .recording-editor-header { grid-template-columns: minmax(150px, 1fr) auto auto; } .recording-editor-ascent .recording-editor-audio-field { grid-column: span 1; } }
 @media (max-width: 620px) { .recording-editor-ascent .recording-editor-header { grid-template-columns: 1fr 1fr; } .recording-editor-ascent .recording-editor-clip-name, .recording-editor-ascent .recording-editor-audio-field { grid-column: 1 / -1; } .recording-editor-timeline-actions { margin-left: 0; } .recording-apm-heading { flex-direction: column; } .recording-apm-heading-actions { width: 100%; } }
 @media (max-width: 1050px) { .recording-settings-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-@media (max-width: 700px) { .recording-heading, .recording-library-toolbar, .recording-player-view-heading { flex-direction: column; align-items: stretch; } .recording-player-heading-actions { margin-left: 0; } .recording-tabs, .recording-search { width: 100%; } .recording-tab { flex: 1; } .recording-settings-grid, .recording-storage-panel, .recording-audio-sections, .recording-quickstart-grid, .recording-capture-target-row { grid-template-columns: 1fr; } .recording-storage-panel .recording-panel-heading { grid-column: auto; } .recording-panel-heading { flex-direction: column; } .recording-storage-heading-meta { width: 100%; justify-content: space-between; } .recording-hotkey-row { grid-template-columns: 1fr 150px; } .recording-hotkey-warning, .recording-hotkey-registered { grid-column: 1 / -1; } .recording-library-actions { flex-wrap: wrap; } .recording-library-actions .recording-search { flex-basis: 100%; } .recording-player-controls { flex-wrap: wrap; } .recording-player-volume { flex: 1; } .recording-player-brand { display: none; } .recording-player-timeline-ruler { padding-inline: 43px; } .recording-target-refresh { width: max-content; } }
+@media (max-width: 700px) { .recording-heading, .recording-library-toolbar, .recording-player-view-heading { flex-direction: column; align-items: stretch; } .recording-player-heading-actions { margin-left: 0; } .recording-tabs, .recording-search { width: 100%; } .recording-tab { flex: 1; } .recording-settings-grid, .recording-storage-panel, .recording-audio-sections, .recording-quickstart-grid, .recording-capture-target-row { grid-template-columns: 1fr; } .recording-storage-panel .recording-panel-heading { grid-column: auto; } .recording-panel-heading { flex-direction: column; } .recording-storage-heading-meta { width: 100%; justify-content: space-between; } .recording-hotkey-row { grid-template-columns: 1fr 150px; } .recording-hotkey-status { grid-column: 1 / -1; } .recording-library-actions { flex-wrap: wrap; } .recording-library-actions .recording-search { flex-basis: 100%; } .recording-player-controls { flex-wrap: wrap; } .recording-player-volume { flex: 1; } .recording-player-brand { display: none; } .recording-player-timeline-ruler { padding-inline: 43px; } .recording-target-refresh { width: max-content; } }
 .recording-delete-modal { width: min(460px, calc(100vw - 32px)); }
 .recording-delete-file { overflow-wrap: anywhere; word-break: break-word; }
 @media (max-width: 900px) { .dashboard-pulse-grid { grid-template-columns: repeat(2, minmax(130px, 1fr)); } }


### PR DESCRIPTION
## Summary
- Make Monitoring metric graphs and grid lanes taller with shared canvas, hover, grid, and crosshair geometry.
- Keep Advanced Overlay Tuning, Fan, Graphics, and Recording views current after cross-window settings/read-back pushes.
- Add a persistent NONE shortcut control that disables and unregisters recording hotkeys on Apply.
- Harden On-Windows-Start startup registration for both Portable and installed builds, including duplicate Portable filenames and Installer-to-installed-app handoff.

## Validation
- `npm run typecheck`
- `npm run build:renderer`
- 145 focused Node tests passed
- `git diff --cached --check`

Targets `main` and is ready for review.