### PR TITLE
Fix recording hotkey capture and Monitoring redraw performance

### DIFF
--- a/src/renderer/components/recording-hotkey-dialog.ts
+++ b/src/renderer/components/recording-hotkey-dialog.ts
@@ -1,0 +1,87 @@
+import { el, clear } from '../dom.ts';
+import { recordingAcceleratorFromKeyboardEvent } from '../pure/recording-hotkey.ts';
+
+const ROOT_ID = 'modal-root';
+
+function modalRoot(): HTMLElement {
+  return document.getElementById(ROOT_ID) ?? (() => {
+    const root = el('div', { id: ROOT_ID });
+    document.body.append(root);
+    return root;
+  })();
+}
+
+/** Capture one supported keyboard accelerator without persisting it. */
+export function showRecordingHotkeyDialog(label: string, current: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const root = modalRoot();
+    clear(root);
+    let closed = false;
+    const finish = (value: string | null): void => {
+      if (closed) return;
+      closed = true;
+      document.removeEventListener('keydown', onKeyDown, true);
+      clear(root);
+      resolve(value);
+    };
+    const value = el('div', { class: 'recording-hotkey-dialog-value', role: 'status', 'aria-live': 'polite', text: current || 'Waiting…' });
+    const hint = el('p', { class: 'recording-hotkey-dialog-hint', text: 'Press a letter, number, or F1–F24. Ctrl, Alt, and Shift can be combined.' });
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        finish(null);
+        return;
+      }
+      // Keep focus inside this small dialog. Cancel is currently the only
+      // focusable control, so both Tab directions remain on that button.
+      if (event.key === 'Tab') {
+        event.preventDefault();
+        cancel.focus();
+        return;
+      }
+      // Leave activation of the focused Cancel button alone. The document
+      // listener runs in capture phase, so preventing Enter/Space here would
+      // make the only modal action unreachable from the keyboard.
+      if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') return;
+      if (MODIFIER_ONLY_KEYS.has(event.key)) return;
+      const accelerator = recordingAcceleratorFromKeyboardEvent(event);
+      if (!accelerator) {
+        event.preventDefault();
+        hint.textContent = 'That key is not supported. Use a letter, number, or F1–F24, with optional Ctrl, Alt, or Shift.';
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      value.textContent = accelerator;
+      finish(accelerator);
+    };
+    const cancel = el('button', { class: 'btn btn-ghost', text: 'Cancel', type: 'button', onClick: () => finish(null) });
+    const overlay = el('div', {
+      class: 'modal-overlay recording-hotkey-dialog-overlay',
+      onClick: (event: Event) => { if (event.target === overlay) finish(null); },
+    }, [
+      el('div', {
+        class: 'modal recording-hotkey-dialog',
+        role: 'dialog',
+        'aria-modal': 'true',
+        'aria-labelledby': 'recording-hotkey-dialog-title',
+        'aria-describedby': 'recording-hotkey-dialog-description',
+      }, [
+        el('span', { class: 'recording-eyebrow', text: 'Shortcuts' }),
+        el('h2', { class: 'modal-title', id: 'recording-hotkey-dialog-title', text: `Set ${label} hotkey` }),
+        el('p', { class: 'modal-text', id: 'recording-hotkey-dialog-description', text: 'Press the exact key or key combination you want to use.' }),
+        el('div', { class: 'recording-hotkey-dialog-capture' }, [
+          el('span', { class: 'recording-hotkey-dialog-capture-label', text: 'Listening for input' }),
+          value,
+        ]),
+        hint,
+        el('div', { class: 'modal-actions' }, [cancel]),
+      ]),
+    ]);
+    root.append(overlay);
+    document.addEventListener('keydown', onKeyDown, true);
+    cancel.focus();
+  });
+}
+
+const MODIFIER_ONLY_KEYS = new Set(['Control', 'Alt', 'Shift', 'Meta']);

--- a/src/renderer/pages/monitoring.ts
+++ b/src/renderer/pages/monitoring.ts
@@ -66,6 +66,8 @@ const FPS_CHECKING_NOTE = 'Checking FPS…';
 interface MonState {
   deviceId: number | null;
   series: Record<string, SeriesPoint[]>;
+  dirtySeries: Set<string>;
+  fullRedrawPending: boolean;
   metricCanvases: Map<string, HTMLCanvasElement>;
   graphCeilings: Map<string, number>;
   rangeNodes: Map<string, { min: HTMLElement; max: HTMLElement }>;
@@ -206,7 +208,10 @@ function systemGraphKey(segmentId: string): string {
 function setGraphCeiling(seriesId: string, value: number | null | undefined): void {
   if (!mon || !Number.isFinite(value) || Number(value) <= 0) return;
   const previous = mon.graphCeilings.get(seriesId) ?? 0;
-  if (Number(value) > previous) mon.graphCeilings.set(seriesId, Number(value));
+  if (Number(value) > previous) {
+    mon.graphCeilings.set(seriesId, Number(value));
+    mon.dirtySeries.add(seriesId);
+  }
 }
 
 /**
@@ -266,6 +271,7 @@ function pushMetricSeries(seriesId: string, t: number, value: number | undefined
     t,
     TELEMETRY_HISTORY_WINDOW_S,
   );
+  mon.dirtySeries.add(seriesId);
 }
 
 function updateMetricBindings(state: AppState): void {
@@ -668,6 +674,8 @@ export const monitoringPage: Page = {
     mon = {
       deviceId: defaultFpsDevice(s)?.id ?? null,
       series: {},
+      dirtySeries: new Set(),
+      fullRedrawPending: false,
       metricCanvases: new Map(),
       graphCeilings: new Map(),
       rangeNodes: new Map(),
@@ -1258,22 +1266,32 @@ function renderMonitoringView(container: HTMLElement, ctx: PageContext): void {
   container.append(workspace);
   const metricsColumn = workspace.querySelector<HTMLElement>('.monitoring-metrics-column');
   if (metricsColumn && typeof ResizeObserver !== 'undefined') {
-    monitoringResizeObserver = new ResizeObserver(() => redrawAll());
+    monitoringResizeObserver = new ResizeObserver(() => redrawAll(true));
     monitoringResizeObserver.observe(metricsColumn);
   }
-  redrawAll();
+  redrawAll(true);
 }
 
-function redrawAll(): void {
-  if (!mon || monView !== 'monitoring' || mon.metricCanvases.size === 0 || graphRedrawFrame !== null) return;
+function redrawAll(force = false): void {
+  if (!mon || monView !== 'monitoring' || mon.metricCanvases.size === 0) return;
+  if (force) mon.fullRedrawPending = true;
+  if (!mon.fullRedrawPending && mon.dirtySeries.size === 0) return;
+  if (graphRedrawFrame !== null) return;
   // A telemetry push is emitted once per adapter, so a multi-GPU machine can
   // deliver multiple store updates in one paint interval. Coalesce those
   // updates into one frame so graphs never render an intermediate snapshot.
   graphRedrawFrame = window.requestAnimationFrame(() => {
     graphRedrawFrame = null;
     if (!mon || monView !== 'monitoring') return;
+    const drawAll = mon.fullRedrawPending;
+    mon.fullRedrawPending = false;
+    const dirty = drawAll ? new Set(mon.metricCanvases.keys()) : new Set(mon.dirtySeries);
+    mon.dirtySeries.clear();
+    if (dirty.size === 0) return;
     const accentColor = cssVar('--accent');
-    for (const [id, canvas] of mon.metricCanvases) {
+    for (const id of dirty) {
+      const canvas = mon.metricCanvases.get(id);
+      if (!canvas) continue;
       const range = drawMiniSeries(canvas, mon.series[id] ?? [], id, monitoringSeriesColor(id, accentColor), mon.graphCeilings.get(id));
       const nodes = mon.rangeNodes.get(id);
       if (nodes) {
@@ -1292,5 +1310,5 @@ function redrawAll(): void {
  * tick). No-op when the Monitoring page is not mounted.
  */
 export function redrawMonitoringGraphs(): void {
-  redrawAll();
+  redrawAll(true);
 }

--- a/src/renderer/pages/recording.ts
+++ b/src/renderer/pages/recording.ts
@@ -7,6 +7,7 @@ import type { DeviceInfo, RecordingAudioDevice, RecordingCaptureTarget, Recordin
 import { toast } from '../components/toast.ts';
 import { showRecordingClipDeleteConfirm } from '../components/recording-delete-dialog.ts';
 import { showRecordingShareDialog, type RecordingShareDialogHandle } from '../components/recording-share-dialog.ts';
+import { showRecordingHotkeyDialog } from '../components/recording-hotkey-dialog.ts';
 import { buildDropdown, type DropdownElement } from '../components/dropdown.ts';
 import { parseRecordingEncoderSelection, recordingAdapterTargetOf, recordingBitrateRange, recordingGpuEncoderOptions, recordingGpuEncoderRows, recordingMessage } from '../pure/recording.ts';
 import { clampRecordingEditorRange, normalizeRecordingEditorClipName, recordingEditorResumePosition, recordingEditorSelectionFromRatios, recordingEditorSeekTargetMs, recordingEditorTimelineMsFromRatio } from '../pure/recording-editor.ts';
@@ -289,6 +290,8 @@ function recordingSettingsPatchFrom(value: RecordingSettings): RecordingSettings
     captureColorMode: value.captureColorMode,
     showCursor: value.showCursor,
     replayLengthSec: value.replayLengthSec,
+    instantReplayAutoStart: value.instantReplayAutoStart,
+    replayMarkersEnabled: value.replayMarkersEnabled,
     audio: {
       microphone: { ...value.audio.microphone },
       system: { ...value.audio.system },
@@ -822,20 +825,34 @@ function renderAudioSettings(): HTMLElement {
 function renderHotkeys(): HTMLElement {
   const working = settingsForRender();
   const make = (key: 'start' | 'stop' | 'saveClip' | 'screenshot', label: string, description: string): HTMLElement => {
-    const input = el('input', {
+    const current = working?.hotkeys[key] ?? '';
+    const focusPicker = (): void => {
+      document.querySelector<HTMLButtonElement>(`[data-recording-hotkey="${key}"]`)?.focus();
+    };
+    const picker = el('button', {
       class: 'recording-hotkey',
-      type: 'text',
-      value: working?.hotkeys[key] ?? '',
-      maxlength: 32,
-      'aria-label': label,
-    }) as HTMLInputElement;
-    input.addEventListener('change', () => stagePatch({ hotkeys: { [key]: input.value } as Partial<RecordingSettings['hotkeys']> }));
+      type: 'button',
+      dataset: { recordingHotkey: key },
+      title: current ? `Change ${label} hotkey` : `Set ${label} hotkey`,
+      'aria-label': `${label} hotkey${current ? `: ${current}` : ': not set'}`,
+      text: current,
+      onClick: () => {
+        void showRecordingHotkeyDialog(label, current).then((next) => {
+          if (next === null) {
+            focusPicker();
+            return;
+          }
+          stagePatch({ hotkeys: { [key]: next } as Partial<RecordingSettings['hotkeys']> });
+          focusPicker();
+        });
+      },
+    }) as HTMLButtonElement;
     const conflict = status.hotkeys.conflicts[key];
     return el('div', { class: 'recording-hotkey-row' }, [
       el('div', { class: 'recording-hotkey-copy' }, [el('strong', { text: label }), el('span', { text: description })]),
-      input,
       el('div', { class: 'recording-hotkey-status' }, [
         conflict ? el('span', { class: 'text-warn recording-hotkey-warning', text: `Not registered (${conflict} is in use)` }) : null,
+        picker,
         button('NONE', () => stagePatch({ hotkeys: { [key]: '' } as Partial<RecordingSettings['hotkeys']> }), 'btn btn-secondary recording-hotkey-none'),
       ]),
     ]);
@@ -1215,7 +1232,7 @@ function renderApmGraph(clip: RecordingClip, durationMs: number, extraClass = ''
     const x = Math.min(width, Math.max(0, ratio * width));
     hoverCrosshair.style.left = `${x}px`;
     hoverCrosshair.hidden = false;
-    tooltip.textContent = `${sample.apm} · ${formatTime(sample.atMs / 1000)}`;
+    tooltip.textContent = `${sample.apm}`;
     tooltip.hidden = false;
     // Keep the compact text next to the nearest sample's dashed line. It is
     // placed on the side with room, matching the Monitoring graph hover.

--- a/src/renderer/pure/recording-hotkey.ts
+++ b/src/renderer/pure/recording-hotkey.ts
@@ -1,0 +1,37 @@
+// Renderer-only keyboard capture helpers for the Recording hotkey picker.
+// Keep this grammar aligned with the recording backend's Electron accelerator
+// normalization: optional Control/Alt/Shift modifiers and a final letter,
+// number, or F1-F24 key.
+
+export type RecordingHotkeyKeyboardEvent = Pick<KeyboardEvent, 'code' | 'key' | 'ctrlKey' | 'altKey' | 'shiftKey' | 'metaKey'>;
+
+const FUNCTION_KEY_PATTERN = /^F(?:[1-9]|1[0-9]|2[0-4])$/;
+const MODIFIER_KEYS = new Set(['Control', 'Alt', 'Shift', 'Meta']);
+
+function keyFromEvent(event: RecordingHotkeyKeyboardEvent): string | null {
+  // KeyboardEvent.key is layout-aware (for example, a German QWERTZ Z key
+  // reports "z"). Prefer that logical key so the displayed accelerator is the
+  // key the user actually pressed, then use code only for synthetic or
+  // incomplete events that do not expose a usable key value.
+  const key = typeof event.key === 'string' ? event.key.toUpperCase() : '';
+  if (/^[A-Z0-9]$/.test(key) || FUNCTION_KEY_PATTERN.test(key)) return key;
+
+  const code = typeof event.code === 'string' ? event.code : '';
+  if (/^Key[A-Z]$/.test(code)) return code.slice(3);
+  if (/^(?:Digit|Numpad)[0-9]$/.test(code)) return code.replace(/^(?:Digit|Numpad)/, '');
+  if (FUNCTION_KEY_PATTERN.test(code)) return code;
+
+  return null;
+}
+
+/** Convert a browser keydown event into the Electron accelerator grammar. */
+export function recordingAcceleratorFromKeyboardEvent(event: RecordingHotkeyKeyboardEvent): string | null {
+  if (MODIFIER_KEYS.has(event.key) || event.metaKey) return null;
+  const key = keyFromEvent(event);
+  if (!key) return null;
+  const modifiers: string[] = [];
+  if (event.ctrlKey) modifiers.push('Control');
+  if (event.altKey) modifiers.push('Alt');
+  if (event.shiftKey) modifiers.push('Shift');
+  return [...modifiers, key].join('+');
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -3335,14 +3335,22 @@ input[type="number"] {
 .recording-process-select { width: 100%; }
 .recording-process-select:disabled { opacity: .52; cursor: not-allowed; }
 .recording-process-refresh { align-self: flex-start; margin-top: 2px; }
-.recording-hotkey-row { display: grid; grid-template-columns: minmax(160px, 1fr) 150px minmax(70px, 1fr); gap: 12px; align-items: center; padding: 9px 0; border-top: 1px solid var(--border); font-size: 12px; }
+.recording-hotkey-row { display: grid; grid-template-columns: minmax(160px, 1fr) minmax(260px, auto); gap: 12px; align-items: center; padding: 9px 0; border-top: 1px solid var(--border); font-size: 12px; }
 .recording-hotkey-row:first-of-type { border-top: 0; }
+.recording-hotkey { display: inline-flex; align-items: center; justify-content: center; width: 150px; min-height: 34px; padding: 7px 9px; overflow: hidden; border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: var(--control-bg); color: var(--text); font: inherit; font-family: var(--mono); text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
+.recording-hotkey:hover, .recording-hotkey:focus-visible { border-color: var(--accent); outline: none; box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent); }
 .recording-hotkey-none { min-height: 34px; padding-inline: 8px; font: 700 10px var(--mono); letter-spacing: .04em; }
-.recording-hotkey { width: 150px; font-family: var(--mono); }
 .recording-hotkey-copy { display: flex; flex-direction: column; gap: 2px; }
 .recording-hotkey-copy span { color: var(--text-dim); font-size: 11px; }
-.recording-hotkey-status { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.recording-hotkey-status { display: flex; align-items: center; justify-content: flex-end; gap: 8px; min-width: 0; }
 .recording-hotkey-warning { font-size: 11px; }
+.recording-hotkey-dialog { width: min(380px, calc(100vw - 32px)); max-width: 380px; padding: 18px 20px; }
+.recording-hotkey-dialog .modal-title { margin-bottom: 8px; }
+.recording-hotkey-dialog .modal-text { margin-bottom: 14px; }
+.recording-hotkey-dialog-capture { display: flex; flex-direction: column; align-items: center; gap: 8px; margin-bottom: 12px; padding: 16px 12px; border: 1px solid color-mix(in srgb, var(--accent) 42%, var(--border-strong)); border-radius: var(--radius-sm); background: color-mix(in srgb, var(--accent) 8%, var(--bg-inset)); box-shadow: inset 0 0 18px color-mix(in srgb, var(--accent) 6%, transparent); }
+.recording-hotkey-dialog-capture-label { color: var(--text-dim); font: 650 10px var(--font); letter-spacing: .08em; text-transform: uppercase; }
+.recording-hotkey-dialog-value { min-height: 27px; color: var(--accent); font: 700 21px var(--mono); letter-spacing: .04em; }
+.recording-hotkey-dialog-hint { min-height: 30px; margin: 0 0 16px; color: var(--text-dim); font-size: 11px; line-height: 1.45; }
 .recording-storage-panel { display: grid; grid-template-columns: minmax(170px, .6fr) minmax(260px, 1fr); gap: 12px 16px; }
 .recording-storage-panel .recording-panel-heading { grid-column: 1 / -1; }
 .recording-storage-controls { display: flex; flex-direction: column; gap: 10px; min-width: 0; }
@@ -3638,7 +3646,7 @@ input[type="number"] {
 @media (max-width: 900px) { .recording-editor-ascent .recording-editor-header { grid-template-columns: minmax(150px, 1fr) auto auto; } .recording-editor-ascent .recording-editor-audio-field { grid-column: span 1; } }
 @media (max-width: 620px) { .recording-editor-ascent .recording-editor-header { grid-template-columns: 1fr 1fr; } .recording-editor-ascent .recording-editor-clip-name, .recording-editor-ascent .recording-editor-audio-field { grid-column: 1 / -1; } .recording-editor-timeline-actions { margin-left: 0; } .recording-apm-heading { flex-direction: column; } .recording-apm-heading-actions { width: 100%; } }
 @media (max-width: 1050px) { .recording-settings-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-@media (max-width: 700px) { .recording-heading, .recording-library-toolbar, .recording-player-view-heading { flex-direction: column; align-items: stretch; } .recording-player-heading-actions { margin-left: 0; } .recording-tabs, .recording-search { width: 100%; } .recording-tab { flex: 1; } .recording-settings-grid, .recording-storage-panel, .recording-audio-sections, .recording-quickstart-grid, .recording-capture-target-row { grid-template-columns: 1fr; } .recording-storage-panel .recording-panel-heading { grid-column: auto; } .recording-panel-heading { flex-direction: column; } .recording-storage-heading-meta { width: 100%; justify-content: space-between; } .recording-hotkey-row { grid-template-columns: 1fr 150px; } .recording-hotkey-status { grid-column: 1 / -1; } .recording-library-actions { flex-wrap: wrap; } .recording-library-actions .recording-search { flex-basis: 100%; } .recording-player-controls { flex-wrap: wrap; } .recording-player-volume { flex: 1; } .recording-player-brand { display: none; } .recording-player-timeline-ruler { padding-inline: 43px; } .recording-target-refresh { width: max-content; } }
+@media (max-width: 700px) { .recording-heading, .recording-library-toolbar, .recording-player-view-heading { flex-direction: column; align-items: stretch; } .recording-player-heading-actions { margin-left: 0; } .recording-tabs, .recording-search { width: 100%; } .recording-tab { flex: 1; } .recording-settings-grid, .recording-storage-panel, .recording-audio-sections, .recording-quickstart-grid, .recording-capture-target-row { grid-template-columns: 1fr; } .recording-storage-panel .recording-panel-heading { grid-column: auto; } .recording-panel-heading { flex-direction: column; } .recording-storage-heading-meta { width: 100%; justify-content: space-between; } .recording-hotkey-row { grid-template-columns: 1fr; } .recording-hotkey-status { grid-column: auto; justify-content: flex-start; flex-wrap: wrap; } .recording-library-actions { flex-wrap: wrap; } .recording-library-actions .recording-search { flex-basis: 100%; } .recording-player-controls { flex-wrap: wrap; } .recording-player-volume { flex: 1; } .recording-player-brand { display: none; } .recording-player-timeline-ruler { padding-inline: 43px; } .recording-target-refresh { width: max-content; } }
 .recording-delete-modal { width: min(460px, calc(100vw - 32px)); }
 .recording-delete-file { overflow-wrap: anywhere; word-break: break-word; }
 @media (max-width: 900px) { .dashboard-pulse-grid { grid-template-columns: repeat(2, minmax(130px, 1fr)); } }


### PR DESCRIPTION
## Summary
- Replace recording hotkey text fields with an Arc-styled keyboard capture dialog, staged until Apply, with NONE disable semantics.
- Keep replay Auto Start and replay marker settings in the Apply payload.
- Show only the clean APM value on hover.
- Redraw only changed Monitoring graphs while preserving full redraws for resize/theme changes.

## Validation
- npm run typecheck
- node --test test/monitoring-layout.test.js test/recording-renderer-contract.test.js test/recording-pure.test.js test/recording-hotkeys.test.js
- npm run build:renderer
- npm run smoke:mock

The repository-wide npm test command was also run; it exits non-zero on existing native/apply/replay/support-content failures outside this change.